### PR TITLE
s2: overlays: Update for new LED capabilities

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -198,9 +198,10 @@ BOARD_HARDWARE_CLASS += device/leeco/s2/lineagehw
 
 # Enable dexpreopt to speed boot time
 ifeq ($(HOST_OS),linux)
-  ifeq ($(call match-word-in-list,$(TARGET_BUILD_VARIANT),user),true)
+  ifneq ($(TARGET_BUILD_VARIANT),eng)
     ifeq ($(WITH_DEXPREOPT),)
       WITH_DEXPREOPT := true
+      WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY := true
     endif
   endif
 endif

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -162,9 +162,6 @@
     <!-- Shutdown if the battery temperature exceeds (this value * 0.1) Celsius. -->
     <integer name="config_shutdownBatteryTemperature">680</integer>
 
-    <!-- Is the battery LED intrusive? Used to decide if there should be a disable option -->
-    <!-- <bool name="config_intrusiveBatteryLed">true</bool> -->
-
     <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
     <bool name="config_intrusiveNotificationLed">true</bool>
 

--- a/overlay/vendor/cmsdk/cm/res/res/values/config.xml
+++ b/overlay/vendor/cmsdk/cm/res/res/values/config.xml
@@ -21,14 +21,16 @@
 
          LIGHTS_RGB_NOTIFICATION_LED = 1
          LIGHTS_RGB_BATTERY_LED = 2
-         LIGHTS_MULTIPLE_NOTIFICATION_LED = 4
+         LIGHTS_MULTIPLE_NOTIFICATION_LED = 4 (deprecated)
          LIGHTS_PULSATING_LED = 8
          LIGHTS_SEGMENTED_BATTERY_LED = 16
          LIGHTS_ADJUSTABLE_NOTIFICATION_LED_BRIGHTNESS = 32
+         LIGHTS_BATTERY_LED = 64
 
-         For example, a device support pulsating, RGB notification and
-         battery LEDs would set this config to 11. -->
-    <integer name="config_deviceLightCapabilities" translatable="false">43</integer>
+         For example, a device with notification and battery lights
+         that support pulsating and RGB control would set this config
+         to 75. -->
+    <integer name="config_deviceLightCapabilities" translatable="false">75</integer>
 
     <!-- Is the notification LED brightness adjustable ? Used to decide if the user can set LED brightness -->
     <bool name="config_adjustableNotificationLedBrightness">true</bool>


### PR DESCRIPTION
*) frameworks/base bool config_intrusiveBatteryLed is no longer
   used so it has been removed.

*) Use LIGHTS_BATTERY_LIGHT capability in lineage-sdk instead.

*) Update config_deviceLightCapabilities comments